### PR TITLE
feat: re-export `ndarray`, `opencv`, and `ort` crates.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,9 @@ pub mod scrfd;
 pub mod scrfd_async;
 
 pub use helpers::*;
+pub use ndarray;
+pub use opencv;
+pub use ort;
 pub use scrfd::SCRFD;
 
 #[cfg(feature = "async")]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Re-export `ndarray`, `opencv`, and `ort` crates in `src/lib.rs` for easier access.
> 
>   - **Re-exports**:
>     - Re-export `ndarray`, `opencv`, and `ort` crates in `src/lib.rs` for easier access through the library's API.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=prabhat0206%2Fscrfd&utm_source=github&utm_medium=referral)<sup> for e5be1e81dc39a1a9947a3688b18602706b66fdbd. You can [customize](https://app.ellipsis.dev/prabhat0206/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->