### PR TITLE
correct ROI dimensions and apply centering offsets for non-square aspect ratios

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -65,8 +65,8 @@ impl SCRFDBuilder {
     /// # Returns
     /// A new builder instance with default parameters:
     /// - Input size: (640, 640)
-    /// - Confidence threshold: 0.5
-    /// - IoU threshold: 0.5
+    /// - Confidence threshold: 0.25
+    /// - IoU threshold: 0.4
     pub fn new(session: Session) -> Self {
         SCRFDBuilder {
             session,

--- a/src/helpers/opencv_helper.rs
+++ b/src/helpers/opencv_helper.rs
@@ -208,18 +208,6 @@ impl OpenCVHelper {
 
         Ok((det_image, det_scale, x_offset, y_offset))
     }
-
-    pub fn draw_rectangle(&self, image: &mut Mat, rect: core::Rect) -> Result<(), Box<dyn Error>> {
-        opencv::imgproc::rectangle(
-            image,
-            rect,
-            core::Scalar::new(0.0, 0.0, 255.0, 0.0),
-            2,
-            opencv::imgproc::LINE_8,
-            0,
-        )?;
-        Ok(())
-    }
 }
 
 #[cfg(test)]

--- a/src/helpers/scrfd_helper.rs
+++ b/src/helpers/scrfd_helper.rs
@@ -89,14 +89,14 @@ impl ScrfdHelpers {
             (x1, y1, x2, y2)
         };
 
-        println!("x1: {:?}", x1);
-        println!("y1: {:?}", y1);
-        println!("x2: {:?}", x2);
-        println!("y2: {:?}", y2);
+        log::trace!("x1: {:?}", x1);
+        log::trace!("y1: {:?}", y1);
+        log::trace!("x2: {:?}", x2);
+        log::trace!("y2: {:?}", y2);
 
         let concatenated =
             ndarray::stack(Axis(1), &[x1.view(), y1.view(), x2.view(), y2.view()]).unwrap();
-        println!("Shape: {:?}", concatenated.shape());
+        log::trace!("Shape: {:?}", concatenated.shape());
         concatenated
     }
 

--- a/src/helpers/scrfd_helper.rs
+++ b/src/helpers/scrfd_helper.rs
@@ -89,14 +89,8 @@ impl ScrfdHelpers {
             (x1, y1, x2, y2)
         };
 
-        log::trace!("x1: {:?}", x1);
-        log::trace!("y1: {:?}", y1);
-        log::trace!("x2: {:?}", x2);
-        log::trace!("y2: {:?}", y2);
-
         let concatenated =
             ndarray::stack(Axis(1), &[x1.view(), y1.view(), x2.view(), y2.view()]).unwrap();
-        log::trace!("Shape: {:?}", concatenated.shape());
         concatenated
     }
 
@@ -352,10 +346,7 @@ impl ScrfdHelpers {
     /// ```
     pub fn concatenate_array2(arrays: &[Array2<f32>]) -> Result<Array2<f32>, Box<dyn Error>> {
         if arrays.is_empty() {
-            if arrays.len() == 0 {
-                return Ok(Array2::<f32>::zeros((0, 0)));
-            }
-            return Ok(Array2::<f32>::zeros((0, arrays[0].shape()[1])));
+            return Ok(Array2::<f32>::zeros((0, 0)));
         }
         Ok(ndarray::concatenate(
             Axis(0),
@@ -391,14 +382,7 @@ impl ScrfdHelpers {
     /// ```
     pub fn concatenate_array3(arrays: &[Array3<f32>]) -> Result<Array3<f32>, Box<dyn Error>> {
         if arrays.is_empty() {
-            if arrays.len() == 0 {
-                return Ok(Array3::<f32>::zeros((0, 0, 0)));
-            }
-            return Ok(Array3::<f32>::zeros((
-                0,
-                arrays[0].shape()[1],
-                arrays[0].shape()[2],
-            )));
+            return Ok(Array3::<f32>::zeros((0, 0, 0)));
         }
         Ok(ndarray::concatenate(
             Axis(0),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,13 +57,13 @@ mod tests {
         let mut center_cache = HashMap::new();
         let (detections, _) = scrfd.detect(&image, 0, "max", &mut center_cache)?;
 
-        println!("Detections: {:?}", detections);
+        log::trace!("Detections: {:?}", detections);
 
         // Draw rectangles around detected faces
         for det in detections.rows() {
             let image_width = image.cols();
             let image_height = image.rows();
-            println!("Image size: {}x{}", image_width, image_height);
+            log::trace!("Image size: {}x{}", image_width, image_height);
 
             let x = det[0];
             let y = det[1];
@@ -134,13 +134,13 @@ mod tests {
         let mut center_cache = HashMap::new();
         let (detections, _) = scrfd.detect(&image, 0, "max", &mut center_cache).await?;
 
-        println!("Async Detections: {:?}", detections);
+        log::trace!("Async Detections: {:?}", detections);
 
         // Draw rectangles around detected faces
         for det in detections.rows() {
             let image_width = image.cols();
             let image_height = image.rows();
-            println!("Image size: {}x{}", image_width, image_height);
+            log::trace!("Image size: {}x{}", image_width, image_height);
 
             let x = det[0];
             let y = det[1];

--- a/src/scrfd.rs
+++ b/src/scrfd.rs
@@ -18,7 +18,6 @@ pub struct SCRFD {
     use_kps: bool,
     opencv_helper: OpenCVHelper,
     session: Session,
-    _output_names: Vec<String>,
     input_names: Vec<String>,
     relative_output: bool,
 }
@@ -48,12 +47,7 @@ impl SCRFD {
         let mean = 127.5;
         let std = 128.0;
 
-        // Get model input and output names
-        let output_names = session
-            .outputs()
-            .iter()
-            .map(|o| o.name().to_string())
-            .collect();
+        // Get model input names
         let input_names = session
             .inputs()
             .iter()
@@ -70,7 +64,6 @@ impl SCRFD {
             use_kps,
             opencv_helper: OpenCVHelper::new(mean, std),
             session,
-            _output_names: output_names,
             input_names,
             relative_output,
         })
@@ -109,12 +102,13 @@ impl SCRFD {
 
         let fmc = self._fmc;
         for (idx, &stride) in self.feat_stride_fpn.iter().enumerate() {
-            let scores = outputs[idx].clone();
+            let scores = &outputs[idx];
             let bbox_preds = outputs[idx + fmc].to_shape((outputs[idx + fmc].len() / 4, 4))?;
-            let bbox_preds = bbox_preds * stride as f32;
-            let kps_preds = outputs[idx + fmc * 2]
+            let bbox_preds = (bbox_preds * stride as f32).into_owned();
+            let kps_preds = (outputs[idx + fmc * 2]
                 .to_shape((outputs[idx + fmc * 2].len() / 10, 10))?
-                * stride as f32;
+                * stride as f32)
+                .into_owned();
 
             // Determine feature map dimensions
             let height = input_height / stride as usize;
@@ -122,20 +116,14 @@ impl SCRFD {
 
             // Generate anchor centers
             let key = (height as i32, width as i32, stride);
-            let anchor_centers = if let Some(centers) = center_cache.get(&key) {
-                centers.clone()
-            } else {
-                let centers = ScrfdHelpers::generate_anchor_centers(
+            let anchor_centers = center_cache.entry(key).or_insert_with(|| {
+                ScrfdHelpers::generate_anchor_centers(
                     self.num_anchors,
                     height,
                     width,
                     stride as f32,
-                );
-                if center_cache.len() < 100 {
-                    center_cache.insert(key, centers.clone());
-                }
-                centers
-            };
+                )
+            });
 
             // Filter scores by threshold
             let pos_inds: Vec<usize> = scores
@@ -150,14 +138,14 @@ impl SCRFD {
             }
 
             let pos_scores = scores.select(Axis(0), &pos_inds);
-            let bboxes = ScrfdHelpers::distance2bbox(&anchor_centers, &bbox_preds.to_owned(), None);
+            let bboxes = ScrfdHelpers::distance2bbox(anchor_centers, &bbox_preds, None);
             let pos_bboxes = bboxes.select(Axis(0), &pos_inds);
 
             scores_list.push(pos_scores.to_shape((pos_scores.len(), 1))?.to_owned());
             bboxes_list.push(pos_bboxes);
 
             if self.use_kps {
-                let kpss = ScrfdHelpers::distance2kps(&anchor_centers, &kps_preds.to_owned(), None);
+                let kpss = ScrfdHelpers::distance2kps(anchor_centers, &kps_preds, None);
                 let kpss = kpss.to_shape((kpss.shape()[0], kpss.shape()[1] / 2, 2))?;
                 let pos_kpss = kpss.select(Axis(0), &pos_inds);
                 kpss_list.push(pos_kpss);
@@ -225,7 +213,11 @@ impl SCRFD {
 
         let scores_ravel = scores.iter().collect::<Vec<_>>();
         let mut order = (0..scores_ravel.len()).collect::<Vec<usize>>();
-        order.sort_unstable_by(|&i, &j| scores_ravel[j].partial_cmp(&scores_ravel[i]).unwrap());
+        order.sort_unstable_by(|&i, &j| {
+            scores_ravel[j]
+                .partial_cmp(&scores_ravel[i])
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
 
         // Prepare pre_detections
         let mut pre_det = ndarray::concatenate(Axis(1), &[bboxes.view(), scores.view()])?;
@@ -245,8 +237,8 @@ impl SCRFD {
             let area = (&det.slice(s![.., 2]) - &det.slice(s![.., 0]))
                 * (&det.slice(s![.., 3]) - &det.slice(s![.., 1]));
             let image_center = (
-                self.input_size.0 as f32 / 2.0,
-                self.input_size.1 as f32 / 2.0,
+                orig_width / 2.0,
+                orig_height / 2.0,
             );
             let offsets = ndarray::stack![
                 Axis(0),
@@ -260,7 +252,11 @@ impl SCRFD {
                 &area - &(offset_dist_squared * 2.0)
             };
             let mut bindex = (0..values.len()).collect::<Vec<usize>>();
-            bindex.sort_unstable_by(|&i, &j| values[j].partial_cmp(&values[i]).unwrap());
+            bindex.sort_unstable_by(|&i, &j| {
+                values[j]
+                    .partial_cmp(&values[i])
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            });
             bindex.truncate(max_num);
             let det = det.select(Axis(0), &bindex);
             if self.use_kps {

--- a/src/scrfd_async.rs
+++ b/src/scrfd_async.rs
@@ -46,9 +46,7 @@ pub struct SCRFDAsync {
     num_anchors: usize,
     use_kps: bool,
     opencv_helper: OpenCVHelper,
-    center_cache: HashMap<(i32, i32, i32), Array2<f32>>,
     session: Session,
-    _output_names: Vec<String>,
     input_names: Vec<String>,
     relative_output: bool,
 }
@@ -99,14 +97,7 @@ impl SCRFDAsync {
         let mean = 127.5;
         let std = 128.0;
 
-        let center_cache = HashMap::new();
-
-        // Get model input and output names
-        let output_names = session
-            .outputs()
-            .iter()
-            .map(|o| o.name().to_string())
-            .collect();
+        // Get model input names
         let input_names = session
             .inputs()
             .iter()
@@ -122,9 +113,7 @@ impl SCRFDAsync {
             num_anchors,
             use_kps,
             opencv_helper: OpenCVHelper::new(mean, std),
-            center_cache,
             session,
-            _output_names: output_names,
             input_names,
             relative_output,
         })
@@ -203,15 +192,15 @@ impl SCRFDAsync {
 
         drop(session_output);
 
-        // reverse the order of outputs
         let fmc = self._fmc;
         for (idx, &stride) in self.feat_stride_fpn.iter().enumerate() {
-            let scores = outputs[idx].clone();
+            let scores = &outputs[idx];
             let bbox_preds = outputs[idx + fmc].to_shape((outputs[idx + fmc].len() / 4, 4))?;
-            let bbox_preds = bbox_preds * stride as f32;
-            let kps_preds = outputs[idx + fmc * 2]
+            let bbox_preds = (bbox_preds * stride as f32).into_owned();
+            let kps_preds = (outputs[idx + fmc * 2]
                 .to_shape((outputs[idx + fmc * 2].len() / 10, 10))?
-                * stride as f32;
+                * stride as f32)
+                .into_owned();
 
             // Determine feature map dimensions
             let height = input_height / stride as usize;
@@ -219,20 +208,14 @@ impl SCRFDAsync {
 
             // Generate anchor centers
             let key = (height as i32, width as i32, stride);
-            let anchor_centers = if let Some(centers) = self.center_cache.get(&key) {
-                centers.clone()
-            } else {
-                let centers = ScrfdHelpers::generate_anchor_centers(
+            let anchor_centers = center_cache.entry(key).or_insert_with(|| {
+                ScrfdHelpers::generate_anchor_centers(
                     self.num_anchors,
                     height,
                     width,
                     stride as f32,
-                );
-                if center_cache.len() < 100 {
-                    center_cache.insert(key, centers.clone());
-                }
-                centers
-            };
+                )
+            });
 
             // Filter scores by threshold
             let pos_inds: Vec<usize> = scores
@@ -247,14 +230,14 @@ impl SCRFDAsync {
             }
 
             let pos_scores = scores.select(Axis(0), &pos_inds);
-            let bboxes = ScrfdHelpers::distance2bbox(&anchor_centers, &bbox_preds.to_owned(), None);
+            let bboxes = ScrfdHelpers::distance2bbox(anchor_centers, &bbox_preds, None);
             let pos_bboxes = bboxes.select(Axis(0), &pos_inds);
 
             scores_list.push(pos_scores.to_shape((pos_scores.len(), 1))?.to_owned());
             bboxes_list.push(pos_bboxes);
 
             if self.use_kps {
-                let kpss = ScrfdHelpers::distance2kps(&anchor_centers, &kps_preds.to_owned(), None);
+                let kpss = ScrfdHelpers::distance2kps(anchor_centers, &kps_preds, None);
                 let kpss = kpss.to_shape((kpss.shape()[0], kpss.shape()[1] / 2, 2))?;
                 let pos_kpss = kpss.select(Axis(0), &pos_inds);
                 kpss_list.push(pos_kpss);
@@ -352,7 +335,11 @@ impl SCRFDAsync {
 
         let scores_ravel = scores.iter().collect::<Vec<_>>();
         let mut order = (0..scores_ravel.len()).collect::<Vec<usize>>();
-        order.sort_unstable_by(|&i, &j| scores_ravel[j].partial_cmp(&scores_ravel[i]).unwrap());
+        order.sort_unstable_by(|&i, &j| {
+            scores_ravel[j]
+                .partial_cmp(&scores_ravel[i])
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
 
         // Prepare pre_detections
         let mut pre_det = ndarray::concatenate(Axis(1), &[bboxes.view(), scores.view()])?;
@@ -372,8 +359,8 @@ impl SCRFDAsync {
             let area = (&det.slice(s![.., 2]) - &det.slice(s![.., 0]))
                 * (&det.slice(s![.., 3]) - &det.slice(s![.., 1]));
             let image_center = (
-                self.input_size.0 as f32 / 2.0,
-                self.input_size.1 as f32 / 2.0,
+                orig_width / 2.0,
+                orig_height / 2.0,
             );
             let offsets = ndarray::stack![
                 Axis(0),
@@ -387,7 +374,11 @@ impl SCRFDAsync {
                 &area - &(offset_dist_squared * 2.0)
             };
             let mut bindex = (0..values.len()).collect::<Vec<usize>>();
-            bindex.sort_unstable_by(|&i, &j| values[j].partial_cmp(&values[i]).unwrap());
+            bindex.sort_unstable_by(|&i, &j| {
+                values[j]
+                    .partial_cmp(&values[i])
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            });
             bindex.truncate(max_num);
             let det = det.select(Axis(0), &bindex);
             if self.use_kps {

--- a/src/scrfd_async.rs
+++ b/src/scrfd_async.rs
@@ -308,7 +308,7 @@ impl SCRFDAsync {
         let orig_width = image.cols() as f32;
         let orig_height = image.rows() as f32;
 
-        let (det_image, det_scale) = self
+        let (det_image, det_scale, x_offset, y_offset) = self
             .opencv_helper
             .resize_with_aspect_ratio(image, self.input_size)?;
         let input_tensor = self
@@ -324,14 +324,28 @@ impl SCRFDAsync {
             return Err("No faces detected".into());
         }
 
-        // Concatenate scores and bboxes
+        // Concatenate scores and bboxes, then remap from canvas coords to
+        // original image coords: original = (canvas - offset) / det_scale
         let scores = ScrfdHelpers::concatenate_array2(&scores_list)?;
-        let bboxes = ScrfdHelpers::concatenate_array2(&bboxes_list)?;
-        let bboxes = &bboxes / det_scale;
+        let mut bboxes = ScrfdHelpers::concatenate_array2(&bboxes_list)?;
+        let x_off = x_offset as f32;
+        let y_off = y_offset as f32;
+        for mut row in bboxes.rows_mut() {
+            row[0] = (row[0] - x_off) / det_scale; // x1
+            row[1] = (row[1] - y_off) / det_scale; // y1
+            row[2] = (row[2] - x_off) / det_scale; // x2
+            row[3] = (row[3] - y_off) / det_scale; // y2
+        }
 
         let mut kpss = if self.use_kps {
-            let kpss = ScrfdHelpers::concatenate_array3(&kpss_list)?;
-            Some(&kpss / det_scale)
+            let mut kpss = ScrfdHelpers::concatenate_array3(&kpss_list)?;
+            for mut face in kpss.outer_iter_mut() {
+                for mut kp in face.rows_mut() {
+                    kp[0] = (kp[0] - x_off) / det_scale; // x
+                    kp[1] = (kp[1] - y_off) / det_scale; // y
+                }
+            }
+            Some(kpss)
         } else {
             None
         };


### PR DESCRIPTION

Enhancement 1 — Wrong ROI width:
Before: used input_height as width (only works for square 640x640)
`Rect::new(0, 0, input_height, new_height)`
After: correct width + centering offset
`Rect::new(x_offset, y_offset, new_width, new_height)`

Enhancement 2 — Offsets computed but never applied: x_offset/y_offset were calculated for centering but discarded with (_, _). Now they're returned and used to remap coordinates in both scrfd.rs and scrfd_async.rs:
`original_coord = (canvas_coord - offset) / det_scale`
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Corrects ROI dimensions and applies centering offsets for non-square aspect ratios in `opencv_helper.rs`, `scrfd.rs`, and `scrfd_async.rs`.
> 
>   - **Behavior**:
>     - Corrects ROI width in `opencv_helper.rs` by using `new_width` and `new_height` with centering offsets.
>     - Applies centering offsets `x_offset` and `y_offset` to remap coordinates in `scrfd.rs` and `scrfd_async.rs`.
>   - **Functions**:
>     - `resize_with_aspect_ratio()` in `opencv_helper.rs` now returns `x_offset` and `y_offset`.
>     - `detect()` in `scrfd.rs` and `scrfd_async.rs` remap coordinates using offsets and scale.
>   - **Misc**:
>     - Updates docstring in `opencv_helper.rs` to reflect new return values.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=prabhat0206%2Fscrfd&utm_source=github&utm_medium=referral)<sup> for d87e578c100a8cddb1347009add18aa6839e1aa2. You can [customize](https://app.ellipsis.dev/prabhat0206/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->